### PR TITLE
Show hidden files on file dialogs for Linux (#259)

### DIFF
--- a/src/NotepadNext/FileDialogHelpers.cpp
+++ b/src/NotepadNext/FileDialogHelpers.cpp
@@ -1,0 +1,93 @@
+/*
+ * This file is part of Notepad Next.
+ * Copyright 2022 Justin Dailey
+ *
+ * Notepad Next is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Notepad Next is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Notepad Next.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+#include "FileDialogHelpers.h"
+
+
+/*
+ * NOTE: This code is nearly identical to the QFileDialog implementation of several static methods.
+ * Since the QDir filter options were not exposed, there was no way to specify QDir::Hiden.
+ */
+
+
+constexpr QDir::Filters default_filters = QDir::AllEntries | QDir::NoDotAndDotDot | QDir::AllDirs | QDir::Files | QDir::Hidden;
+
+
+QList<QUrl> FileDialogHelpers::getOpenFileUrls(QWidget *parent, const QString &caption, const QString &dir, const QString &filter, QString *selectedFilter, QFileDialog::Options options, const QStringList &supportedSchemes)
+{
+    QFileDialog dialog(parent, caption, dir, filter);
+
+    dialog.setSupportedSchemes(supportedSchemes);
+    dialog.setFilter(default_filters);
+    dialog.setOptions(options);
+
+    if (selectedFilter && !selectedFilter->isEmpty())
+        dialog.selectNameFilter(*selectedFilter);
+    if (dialog.exec() == QDialog::Accepted) {
+        if (selectedFilter)
+            *selectedFilter = dialog.selectedNameFilter();
+        return dialog.selectedUrls();
+    }
+    return QList<QUrl>();
+}
+
+QStringList FileDialogHelpers::getOpenFileNames(QWidget *parent, const QString &caption, const QString &dir, const QString &filter, QString *selectedFilter, QFileDialog::Options options)
+{
+    const QStringList schemes = QStringList(QStringLiteral("file"));
+    const QList<QUrl> selectedUrls = getOpenFileUrls(parent, caption, dir, filter, selectedFilter, options, schemes);
+    QStringList fileNames;
+
+    fileNames.reserve(selectedUrls.size());
+    for (const QUrl &url : selectedUrls) {
+        if (url.isLocalFile() || url.isEmpty())
+            fileNames << url.toLocalFile();
+        else
+            fileNames << url.toString();
+    }
+    return fileNames;
+}
+
+QUrl FileDialogHelpers::getSaveFileUrl(QWidget *parent, const QString &caption, const QString &dir, const QString &filter, QString *selectedFilter, QFileDialog::Options options, const QStringList &supportedSchemes)
+{
+    QFileDialog dialog(parent, caption, dir, filter);
+
+    dialog.setSupportedSchemes(supportedSchemes);
+    dialog.setAcceptMode(QFileDialog::AcceptSave);
+    dialog.setFilter(default_filters);
+    dialog.setOptions(options);
+
+    if (selectedFilter && !selectedFilter->isEmpty())
+        dialog.selectNameFilter(*selectedFilter);
+    if (dialog.exec() == QDialog::Accepted) {
+        if (selectedFilter)
+            *selectedFilter = dialog.selectedNameFilter();
+        return dialog.selectedUrls().value(0);
+    }
+    return QUrl();
+}
+
+QString FileDialogHelpers::getSaveFileName(QWidget *parent, const QString &caption, const QString &dir, const QString &filter, QString *selectedFilter, QFileDialog::Options options)
+{
+    const QStringList schemes = QStringList(QStringLiteral("file"));
+    const QUrl selectedUrl = getSaveFileUrl(parent, caption, dir, filter, selectedFilter, options, schemes);
+    if (selectedUrl.isLocalFile() || selectedUrl.isEmpty())
+        return selectedUrl.toLocalFile();
+    else
+        return selectedUrl.toString();
+}

--- a/src/NotepadNext/FileDialogHelpers.h
+++ b/src/NotepadNext/FileDialogHelpers.h
@@ -1,0 +1,35 @@
+/*
+ * This file is part of Notepad Next.
+ * Copyright 2022 Justin Dailey
+ *
+ * Notepad Next is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Notepad Next is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Notepad Next.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+#ifndef FILEDIALOGHELPERS_H
+#define FILEDIALOGHELPERS_H
+
+#include <QWidget>
+#include <QFileDialog>
+
+namespace FileDialogHelpers
+{
+    QList<QUrl> getOpenFileUrls(QWidget *parent, const QString &caption, const QString &dir, const QString &filter, QString *selectedFilter, QFileDialog::Options options, const QStringList &supportedSchemes);
+    QStringList getOpenFileNames(QWidget *parent = nullptr, const QString &caption = QString(), const QString &dir = QString(), const QString &filter = QString(), QString *selectedFilter = nullptr, QFileDialog::Options options = QFileDialog::Options());
+
+    QUrl getSaveFileUrl(QWidget *parent, const QString &caption, const QString &dir, const QString &filter, QString *selectedFilter, QFileDialog::Options options, const QStringList &supportedSchemes);
+    QString getSaveFileName(QWidget *parent = nullptr, const QString &caption = QString(), const QString &dir = QString(), const QString &filter = QString(), QString *selectedFilter = nullptr, QFileDialog::Options options = QFileDialog::Options());
+}
+
+#endif // FILEDIALOGHELPERS_H

--- a/src/NotepadNext/NotepadNext.pro
+++ b/src/NotepadNext/NotepadNext.pro
@@ -65,6 +65,7 @@ SOURCES += \
     EditorHexViewerTableModel.cpp \
     EditorManager.cpp \
     EditorPrintPreviewRenderer.cpp \
+    FileDialogHelpers.cpp \
     Finder.cpp \
     IFaceTable.cpp \
     IFaceTableMixer.cpp \
@@ -130,6 +131,7 @@ HEADERS += \
     EditorHexViewerTableModel.h \
     EditorManager.h \
     EditorPrintPreviewRenderer.h \
+    FileDialogHelpers.h \
     Finder.h \
     FocusWatcher.h \
     IFaceTable.h \

--- a/src/NotepadNext/dialogs/MainWindow.cpp
+++ b/src/NotepadNext/dialogs/MainWindow.cpp
@@ -68,6 +68,7 @@
 #include "MacroEditorDialog.h"
 
 #include "ZoomEventWatcher.h"
+#include "FileDialogHelpers.h"
 
 
 MainWindow::MainWindow(NotepadNextApplication *app) :
@@ -746,7 +747,7 @@ void MainWindow::openFileDialog()
         dialogDir = editor->getPath();
     }
 
-    QStringList fileNames = QFileDialog::getOpenFileNames(this, QString(), dialogDir, filter, Q_NULLPTR);
+    QStringList fileNames = FileDialogHelpers::getOpenFileNames(this, QString(), dialogDir, filter);
 
     openFileList(fileNames);
 }
@@ -939,7 +940,7 @@ bool MainWindow::saveCurrentFileAsDialog()
         dialogDir = editor->getFilePath();
     }
 
-    QString fileName = QFileDialog::getSaveFileName(this, QString(), dialogDir, filter, Q_NULLPTR);
+    QString fileName = FileDialogHelpers::getSaveFileName(this, QString(), dialogDir, filter);
 
     if (fileName.size() == 0) {
         return false;
@@ -976,7 +977,7 @@ void MainWindow::saveCopyAsDialog()
         dialogDir = editor->getFilePath();
     }
 
-    QString fileName = QFileDialog::getSaveFileName(this, tr("Save a Copy As"), dialogDir, filter, Q_NULLPTR);
+    QString fileName = FileDialogHelpers::getSaveFileName(this, tr("Save a Copy As"), dialogDir, filter);
 
     saveCopyAs(fileName);
 }
@@ -1000,7 +1001,7 @@ void MainWindow::renameFile()
 
     Q_ASSERT(editor->isFile());
 
-    QString fileName = QFileDialog::getSaveFileName(this, tr("Rename"), editor->getFilePath());
+    QString fileName = FileDialogHelpers::getSaveFileName(this, tr("Rename"), editor->getFilePath());
 
     if (fileName.size() == 0) {
         return;


### PR DESCRIPTION
Several QFileDialog static methods had to be copied and slightly tweaked so that the QDir::Filters can be specified.

See https://github.com/dail8859/NotepadNext/discussions/255